### PR TITLE
fix: set sdboot-is-embloader architecture to all

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -36,7 +36,7 @@ Description: Embedded Bootloader
   - Initramfs loading
 
 Package: sdboot-is-embloader
-Architecture: any
+Architecture: all
 Depends: embloader (= ${binary:Version}),
          systemd-boot,
          ${misc:Depends}


### PR DESCRIPTION
https://github.com/BigfootACA/embloader/commit/e234d870cea8ad4fb0edddeef4792db35446512d#r168011015