### PR TITLE
debian: divert signed bootloader

### DIFF
--- a/debian/sdboot-is-embloader.postinst
+++ b/debian/sdboot-is-embloader.postinst
@@ -25,16 +25,16 @@ case "$1" in
                 ;;
         esac
 
-        SDBOOT_PATH="/usr/lib/systemd/boot/efi/$SDBOOT_EFI"
-
-        if ! dpkg-divert --list "$SDBOOT_PATH" | grep -q "$PACKAGE"; then
-            if [ -f "$SDBOOT_PATH" ] || [ -L "$SDBOOT_PATH" ]; then
-                dpkg-divert --package "$PACKAGE" --divert "${SDBOOT_PATH}.distrib" \
-                    --rename "$SDBOOT_PATH"
+        for SDBOOT_PATH in "/usr/lib/systemd/boot/efi/$SDBOOT_EFI" "/usr/lib/systemd/boot/efi/$SDBOOT_EFI.signed"; do
+            if ! dpkg-divert --list "$SDBOOT_PATH" | grep -q "$PACKAGE"; then
+                if [ -f "$SDBOOT_PATH" ] || [ -L "$SDBOOT_PATH" ]; then
+                    dpkg-divert --package "$PACKAGE" --divert "${SDBOOT_PATH}.distrib" \
+                        --rename "$SDBOOT_PATH"
+                fi
             fi
-        fi
 
-        cp /usr/share/embloader/embloader.efi "$SDBOOT_PATH"
+            cp /usr/share/embloader/embloader.efi "$SDBOOT_PATH"
+        done
         ;;
 esac
 

--- a/debian/sdboot-is-embloader.prerm
+++ b/debian/sdboot-is-embloader.prerm
@@ -25,15 +25,15 @@ case "$1" in
                 ;;
         esac
 
-        SDBOOT_PATH="/usr/lib/systemd/boot/efi/$SDBOOT_EFI"
+        for SDBOOT_PATH in "/usr/lib/systemd/boot/efi/$SDBOOT_EFI" "/usr/lib/systemd/boot/efi/$SDBOOT_EFI.signed"; do
+            if [ -f "$SDBOOT_PATH" ] || [ -L "$SDBOOT_PATH" ]; then
+                rm -f "$SDBOOT_PATH"
+            fi
 
-        if [ -f "$SDBOOT_PATH" ] || [ -L "$SDBOOT_PATH" ]; then
-            rm -f "$SDBOOT_PATH"
-        fi
-
-        if dpkg-divert --list "$SDBOOT_PATH" | grep -q "$PACKAGE"; then
-            dpkg-divert --package "$PACKAGE" --rename --remove "$SDBOOT_PATH"
-        fi
+            if dpkg-divert --list "$SDBOOT_PATH" | grep -q "$PACKAGE"; then
+                dpkg-divert --package "$PACKAGE" --rename --remove "$SDBOOT_PATH"
+            fi
+        done
         ;;
 esac
 


### PR DESCRIPTION
This is used by Debian 13.

Fixes #11