### PR TITLE
embloader: menu: explicitly set default behavior of edit bootargs to N

### DIFF
--- a/embloader/src/menu/menus/text_menu.c
+++ b/embloader/src/menu/menus/text_menu.c
@@ -12,7 +12,7 @@ static void show_ask_editor(embloader_loader *item, uint64_t *flags) {
 	char edit_input[8], *buffer;
 	if (!item->editor) return;
 	while (true) {
-		printf("Edit bootargs? (y/n): ");
+		printf("Edit bootargs? (y/N): ");
 		fflush(stdout);
 		memset(edit_input, 0, sizeof(edit_input));
 		status = efi_readline(
@@ -21,6 +21,7 @@ static void show_ask_editor(embloader_loader *item, uint64_t *flags) {
 			g_embloader.menu->timeout
 		);
 		if (EFI_ERROR(status)) return;
+		if (strlen(edit_input) == 0) return;
 		if (string_is_true(edit_input)) break;
 		if (string_is_false(edit_input)) return;
 		printf("Invalid choice '%s'\n", edit_input);


### PR DESCRIPTION
When user just press enter at the question, we will have a empty string.

Due to implementation detail of strncasecmp, this string will satisify both string_is_true and string_is_false.

Add an explicit len check, as well as a conventional char captilization to signal the default choice.

Signed-off-by: ZHANG Yuntian <yt@radxa.com>